### PR TITLE
customization #5 fix the relinked message on timeline

### DIFF
--- a/frappe/desk/doctype/communication_reconciliation/communication_reconciliation.py
+++ b/frappe/desk/doctype/communication_reconciliation/communication_reconciliation.py
@@ -75,7 +75,8 @@ class CommunicationReconciliation(Document):
 				"subject": subject,
 				"communication_medium": communication_medium,
 				"reference_owner": frappe.db.get_value(changed_list[comm]["reference_doctype"], changed_list[comm]["reference_name"], "owner"),
-				"content": content
+				"content": content,
+				"sender":frappe.session.user
 			}).insert(ignore_permissions=True)
 
 		return self.fetch()
@@ -117,7 +118,8 @@ def relink(name,reference_doctype,reference_name):
 				"subject": subject,
 				"communication_medium": frappe.db.get_value("Communication",name,"communication_medium"),
 				"reference_owner": frappe.db.get_value(dt, dn, "owner"),
-				"content": content
+				"content": content,
+				"sender":frappe.session.user
 			}).insert(ignore_permissions=True)
 
 def get_communication_doctype(doctype, txt, searchfield, start, page_len, filters):

--- a/frappe/patches.txt
+++ b/frappe/patches.txt
@@ -120,3 +120,5 @@ frappe.patches.v6_21.print_settings_repeat_header_footer
 frappe.patches.v6_24.set_language_as_code
 frappe.patches.v6_20x.update_insert_after
 frappe.patches.v6_24.sync_desktop_icons
+frappe.patches.v6_24.update_sender_in_communication_for_relinked
+

--- a/frappe/patches/v6_24/update_sender_in_communication_for_relinked.py
+++ b/frappe/patches/v6_24/update_sender_in_communication_for_relinked.py
@@ -1,0 +1,5 @@
+import frappe
+
+def execute():
+	frappe.db.sql('''update `tabCommunication` set sender=owner
+		where comment_type='Relinked' and sender is null''')


### PR DESCRIPTION
Fill sender filed in communication when generating Relinked comment record to fix the message on timeline. Patch is for updating existed data.